### PR TITLE
Delete txt records

### DIFF
--- a/api.go
+++ b/api.go
@@ -107,6 +107,42 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	w.Write(upd)
 }
 
+func webDeletePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var delStatus int
+	var del []byte
+	// Get user
+	a, ok := r.Context().Value(ACMETxtKey).(ACMETxt)
+	if !ok {
+		log.WithFields(log.Fields{"error": "context"}).Error("Context error")
+	}
+	// NOTE: An invalid subdomain should not happen - the auth handler should
+	// reject POSTs with an invalid subdomain before this handler. Reject any
+	// invalid subdomains anyway as a matter of caution.
+	if !validSubdomain(a.Subdomain) {
+		log.WithFields(log.Fields{"error": "subdomain", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad delete data")
+		delStatus = http.StatusBadRequest
+		del = jsonError("bad_subdomain")
+	} else if !validTXT(a.Value) {
+		log.WithFields(log.Fields{"error": "txt", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad delete data")
+		delStatus = http.StatusBadRequest
+		del = jsonError("bad_txt")
+	} else if validSubdomain(a.Subdomain) && validTXT(a.Value) {
+		err := DB.Update(a.ACMETxtPost)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to delete record")
+			delStatus = http.StatusInternalServerError
+			del = jsonError("db_error")
+		} else {
+			log.WithFields(log.Fields{"subdomain": a.Subdomain, "txt": a.Value}).Debug("TXT deleted")
+			delStatus = http.StatusOK
+			del = []byte("{\"txt\": \"" + a.Value + "\"}")
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(delStatus)
+	w.Write(del)
+}
+
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusOK)

--- a/api_test.go
+++ b/api_test.go
@@ -74,8 +74,10 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 	api.GET("/health", healthCheck)
 	if noauth {
 		api.POST("/update", noAuth(webUpdatePost))
+		api.POST("/delete", noAuth(webDeletePost))
 	} else {
 		api.POST("/update", Auth(webUpdatePost))
+		api.POST("/delete", Auth(webDeletePost))
 	}
 	return c.Handler(api)
 }
@@ -221,6 +223,36 @@ func TestApiUpdateWithInvalidSubdomain(t *testing.T) {
 		ValueEqual("error", "forbidden")
 }
 
+func TestApiDeleteWithInvalidSubdomain(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	// Invalid subdomain data
+	updateJSON["subdomain"] = "example.com"
+	updateJSON["txt"] = validTxtData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt").
+		ValueEqual("error", "forbidden")
+}
+
 func TestApiUpdateWithInvalidTxt(t *testing.T) {
 	invalidTXTData := "idk m8 bbl lmao"
 
@@ -251,12 +283,54 @@ func TestApiUpdateWithInvalidTxt(t *testing.T) {
 		ValueEqual("error", "bad_txt")
 }
 
+func TestApiDeleteWithInvalidTxt(t *testing.T) {
+	invalidTXTData := "idk m8 bbl lmao"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	updateJSON["subdomain"] = newUser.Subdomain
+	// Invalid txt data
+	updateJSON["txt"] = invalidTXTData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt").
+		ValueEqual("error", "bad_txt")
+}
+
 func TestApiUpdateWithoutCredentials(t *testing.T) {
 	router := setupRouter(false, false)
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
 	e.POST("/update").Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt")
+}
+
+func TestApiDeleteWithoutCredentials(t *testing.T) {
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	e.POST("/delete").Expect().
 		Status(http.StatusUnauthorized).
 		JSON().Object().
 		ContainsKey("error").
@@ -293,6 +367,36 @@ func TestApiUpdateWithCredentials(t *testing.T) {
 		ValueEqual("txt", validTxtData)
 }
 
+func TestApiDeleteWithCredentials(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	// Valid data
+	updateJSON["subdomain"] = newUser.Subdomain
+	updateJSON["txt"] = validTxtData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("txt").
+		NotContainsKey("error").
+		ValueEqual("txt", validTxtData)
+}
+
 func TestApiUpdateWithCredentialsMockDB(t *testing.T) {
 	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	updateJSON := map[string]interface{}{
@@ -314,6 +418,35 @@ func TestApiUpdateWithCredentialsMockDB(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
 	e.POST("/update").
+		WithJSON(updateJSON).
+		Expect().
+		Status(http.StatusInternalServerError).
+		JSON().Object().
+		ContainsKey("error")
+	DB.SetBackend(oldDb)
+}
+
+func TestApiDeleteWithCredentialsMockDB(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	// Valid data
+	updateJSON["subdomain"] = "a097455b-52cc-4569-90c8-7a4b97c6eba8"
+	updateJSON["txt"] = validTxtData
+
+	router := setupRouter(false, true)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	oldDb := DB.GetBackend()
+	db, mock, _ := sqlmock.New()
+	DB.SetBackend(db)
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
+	e.POST("/delete").
 		WithJSON(updateJSON).
 		Expect().
 		Status(http.StatusInternalServerError).
@@ -383,6 +516,67 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 	}
 }
 
+func TestApiManyDeleteWithCredentials(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(true, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	// User without defined CIDR masks
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+
+	// User with defined allow from - CIDR masks, all invalid
+	// (httpexpect doesn't provide a way to mock remote ip)
+	newUserWithCIDR, err := DB.Register(cidrslice{"192.168.1.1/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with CIDR, got error [%v]", err)
+	}
+
+	// Another user with valid CIDR mask to match the httpexpect default
+	newUserWithValidCIDR, err := DB.Register(cidrslice{"10.1.2.3/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with a valid CIDR, got error [%v]", err)
+	}
+
+	for _, test := range []struct {
+		user      string
+		pass      string
+		subdomain string
+		txt       interface{}
+		status    int
+	}{
+		{"non-uuid-user", "tooshortpass", "non-uuid-subdomain", validTxtData, 401},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", "tooshortpass", "bb97455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", "LongEnoughPassButNoUserExists___________", "bb97455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{newUser.Username.String(), newUser.Password, "a097455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, "tooshortfortxt", 400},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, 1234567890, 400},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, validTxtData, 200},
+		{newUserWithCIDR.Username.String(), newUserWithCIDR.Password, newUserWithCIDR.Subdomain, validTxtData, 401},
+		{newUserWithValidCIDR.Username.String(), newUserWithValidCIDR.Password, newUserWithValidCIDR.Subdomain, validTxtData, 200},
+		{newUser.Username.String(), "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", newUser.Subdomain, validTxtData, 401},
+	} {
+		updateJSON = map[string]interface{}{
+			"subdomain": test.subdomain,
+			"txt":       test.txt}
+		e.POST("/delete").
+			WithJSON(updateJSON).
+			WithHeader("X-Api-User", test.user).
+			WithHeader("X-Api-Key", test.pass).
+			WithHeader("X-Forwarded-For", "10.1.2.3").
+			Expect().
+			Status(test.status)
+	}
+}
+
 func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 
 	updateJSON := map[string]interface{}{
@@ -429,6 +623,62 @@ func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 			"subdomain": test.user.Subdomain,
 			"txt":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 		e.POST("/update").
+			WithJSON(updateJSON).
+			WithHeader("X-Api-User", test.user.Username.String()).
+			WithHeader("X-Api-Key", test.user.Password).
+			WithHeader("X-Forwarded-For", test.headerValue).
+			Expect().
+			Status(test.status)
+	}
+	Config.API.UseHeader = false
+}
+
+func TestApiManyDeleteWithIpCheckHeaders(t *testing.T) {
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	// Use header checks from default header (X-Forwarded-For)
+	Config.API.UseHeader = true
+	// User without defined CIDR masks
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+
+	newUserWithCIDR, err := DB.Register(cidrslice{"192.168.1.2/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with CIDR, got error [%v]", err)
+	}
+
+	newUserWithIP6CIDR, err := DB.Register(cidrslice{"2002:c0a8::0/32"})
+	if err != nil {
+		t.Errorf("Could not create a new user with IP6 CIDR, got error [%v]", err)
+	}
+
+	for _, test := range []struct {
+		user        ACMETxt
+		headerValue string
+		status      int
+	}{
+		{newUser, "whatever goes", 200},
+		{newUser, "10.0.0.1, 1.2.3.4 ,3.4.5.6", 200},
+		{newUserWithCIDR, "127.0.0.1", 401},
+		{newUserWithCIDR, "10.0.0.1, 10.0.0.2, 192.168.1.3", 401},
+		{newUserWithCIDR, "10.1.1.1 ,192.168.1.2, 8.8.8.8", 200},
+		{newUserWithIP6CIDR, "2002:c0a8:b4dc:0d3::0", 200},
+		{newUserWithIP6CIDR, "2002:c0a7:0ff::0", 401},
+		{newUserWithIP6CIDR, "2002:c0a8:d3ad:b33f:c0ff:33b4:dc0d:3b4d", 200},
+	} {
+		updateJSON = map[string]interface{}{
+			"subdomain": test.user.Subdomain,
+			"txt":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+		e.POST("/delete").
 			WithJSON(updateJSON).
 			WithHeader("X-Api-User", test.user.Username.String()).
 			WithHeader("X-Api-Key", test.user.Password).

--- a/dns_test.go
+++ b/dns_test.go
@@ -18,6 +18,13 @@ type resolver struct {
 	server string
 }
 
+type testRecord struct {
+	subDomain   string
+	expTXT      []string
+	getAnswer   bool
+	validAnswer bool
+}
+
 func (r *resolver) lookup(host string, qtype uint16) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
@@ -34,13 +41,21 @@ func (r *resolver) lookup(host string, qtype uint16) (*dns.Msg, error) {
 	return in, nil
 }
 
-func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT string) error {
+func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT []string) error {
+	matches := 0
+	txts := 0
+
+OUTER:
 	for _, record := range answer {
-		// We expect only one answer, so no need to loop through the answer slice
+		// Verify all expected answers are returned
 		if rec, ok := record.(*dns.TXT); ok {
 			for _, txtValue := range rec.Txt {
-				if txtValue == cmpTXT {
-					return nil
+				txts++
+				for _, cmpValue := range cmpTXT {
+					if txtValue == cmpValue {
+						matches++
+						continue OUTER
+					}
 				}
 			}
 		} else {
@@ -48,7 +63,76 @@ func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT string) error {
 			return errors.New(errmsg)
 		}
 	}
-	return errors.New("Expected answer not found")
+
+	//Got too many results
+	if txts > len(cmpTXT) {
+		errmsg := fmt.Sprintf("Got too many answers [%d > %d]", txts, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if txts < len(cmpTXT) {
+		//Got too few results
+		errmsg := fmt.Sprintf("Got too few answers [%d < %d]", txts, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches > len(cmpTXT) {
+		//Got too many matches
+		errmsg := fmt.Sprintf("Got too many matches [%d > %d]", matches, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches < len(cmpTXT) {
+		//Got not enough matches
+		errmsg := fmt.Sprintf("Got too few matches [%d > %d]", matches, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches == len(cmpTXT) {
+		//If they all matched we are ok
+		return nil
+	}
+
+	return errors.New("Expected answer(s) not found")
+}
+
+func hasExpectedResolveTXTs(t *testing.T, seq int, tests []testRecord) bool {
+	resolv := resolver{server: "127.0.0.1:15353"}
+
+	for i, test := range tests {
+		answer, err := resolv.lookup(test.subDomain+".auth.example.org", dns.TypeTXT)
+		if err != nil {
+			if test.getAnswer {
+				t.Fatalf("Test %d-%d: Expected answer but got: %v", seq, i, err)
+				return false
+			}
+		} else {
+			if !test.getAnswer {
+				t.Errorf("Test %d-%d: Expected no answer, but got one.", seq, i)
+				return false
+			}
+		}
+
+		if len(answer.Answer) > 0 {
+			if !test.getAnswer && answer.Answer[0].Header().Rrtype != dns.TypeSOA {
+				t.Errorf("Test %d-%d: Expected no answer, but got: [%q]", seq, i, answer)
+				return false
+			}
+			if test.getAnswer {
+				err = hasExpectedTXTAnswer(answer.Answer, test.expTXT)
+				if err != nil {
+					if test.validAnswer {
+						t.Errorf("Test %d-%d: %v", seq, i, err)
+						return false
+					}
+				} else {
+					if !test.validAnswer {
+						t.Errorf("Test %d-%d: Answer was not expected to be valid, answer [%q], compared to [%s]", seq, i, answer, test.expTXT)
+						return false
+					}
+				}
+			}
+		} else {
+			if test.getAnswer {
+				t.Errorf("Test %d-%d: Expected answer, but didn't get one", seq, i)
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func TestQuestionDBError(t *testing.T) {
@@ -199,8 +283,8 @@ func TestAuthoritative(t *testing.T) {
 }
 
 func TestResolveTXT(t *testing.T) {
-	resolv := resolver{server: "127.0.0.1:15353"}
 	validTXT := "______________valid_response_______________"
+	validTXT2 := "_____________valid_response_2______________"
 
 	atxt, err := DB.Register(cidrslice{})
 	if err != nil {
@@ -214,49 +298,63 @@ func TestResolveTXT(t *testing.T) {
 		return
 	}
 
-	for i, test := range []struct {
-		subDomain   string
-		expTXT      string
-		getAnswer   bool
-		validAnswer bool
-	}{
-		{atxt.Subdomain, validTXT, true, true},
-		{atxt.Subdomain, "invalid", true, false},
-		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", validTXT, false, false},
-	} {
-		answer, err := resolv.lookup(test.subDomain+".auth.example.org", dns.TypeTXT)
-		if err != nil {
-			if test.getAnswer {
-				t.Fatalf("Test %d: Expected answer but got: %v", i, err)
-			}
-		} else {
-			if !test.getAnswer {
-				t.Errorf("Test %d: Expected no answer, but got one.", i)
-			}
-		}
-
-		if len(answer.Answer) > 0 {
-			if !test.getAnswer && answer.Answer[0].Header().Rrtype != dns.TypeSOA {
-				t.Errorf("Test %d: Expected no answer, but got: [%q]", i, answer)
-			}
-			if test.getAnswer {
-				err = hasExpectedTXTAnswer(answer.Answer, test.expTXT)
-				if err != nil {
-					if test.validAnswer {
-						t.Errorf("Test %d: %v", i, err)
-					}
-				} else {
-					if !test.validAnswer {
-						t.Errorf("Test %d: Answer was not expected to be valid, answer [%q], compared to [%s]", i, answer, test.expTXT)
-					}
-				}
-			}
-		} else {
-			if test.getAnswer {
-				t.Errorf("Test %d: Expected answer, but didn't get one", i)
-			}
-		}
+	success := false
+	success = hasExpectedResolveTXTs(t, 0, []testRecord{
+		{atxt.Subdomain, []string{validTXT}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if success != true {
+		return
 	}
+
+	//Add 2nd record and verify it works as expected (both results)
+	atxt.Value = validTXT2
+	err = DB.Update(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not update db record: [%v]", err)
+		return
+	}
+
+	success = hasExpectedResolveTXTs(t, 1, []testRecord{
+		{atxt.Subdomain, []string{validTXT, validTXT2}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if success != true {
+		return
+	}
+
+	//Delete the record and rerun the test, should see only first result again
+	atxt.Value = validTXT2
+	err = DB.Delete(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not delete db record: [%v]", err)
+		return
+	}
+
+	success = hasExpectedResolveTXTs(t, 2, []testRecord{
+		{atxt.Subdomain, []string{validTXT}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if success != true {
+		return
+	}
+
+	//Delete the record and rerun the test, should see nothing
+	atxt.Value = validTXT
+	err = DB.Delete(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not delete db record: [%v]", err)
+		return
+	}
+
+	success = hasExpectedResolveTXTs(t, 3, []testRecord{
+		{atxt.Subdomain, []string{"empty"}, false, false},
+		{atxt.Subdomain, []string{"invalid"}, false, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
 }
 
 func TestCaseInsensitiveResolveA(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		api.POST("/register", webRegisterPost)
 	}
 	api.POST("/update", Auth(webUpdatePost))
+	api.POST("/delete", Auth(webDeletePost))
 	api.GET("/health", healthCheck)
 
 	host := Config.API.IP + ":" + Config.API.Port

--- a/types.go
+++ b/types.go
@@ -75,6 +75,7 @@ type database interface {
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxtPost) error
+	Delete(ACMETxtPost) error
 	GetBackend() *sql.DB
 	SetBackend(*sql.DB)
 	Close()


### PR DESCRIPTION
- Added /delete API endpoint to call DB.Delete, structured off /update - Functionally nearly identical with just some strings and the DB call adjusted.

- Added test functions, structured off update tests, for the API for the delete endpoint.

- Added DB.Delete function to DB to set the LastUpdate to 0 for the record being deleted.

- Changed DB.GetTXTForDomain to only return records with LastUpdate > 0

- Adjusted the test function TestResolveTXT to include tests for multiple records and deleting records. This update created a new function to reduce copy/paste, this code lives in hasExpectedResolveTXTs

- Adjusted the test function hasExpectedTXTAnswer to handle checking for the correct number of records, and verifying all expected records are returned