### PR TITLE
Create an index for Subdomain on TXT table

### DIFF
--- a/db.go
+++ b/db.go
@@ -48,7 +48,8 @@ var txtTablePG = `
 		LastUpdate INT
 	);`
 
-var txtTableIndex = `CREATE INDEX IF NOT EXIST txtSubdomainIndex ON txt(Subdomain);`
+var txtTableIndex = `CREATE INDEX IF NOT EXISTS txtSubdomainIndex ON txt(Subdomain, LastUpdate);`
+var txtTableIndexPG = `CREATE INDEX IF NOT EXISTS txtRowIdIndex ON txt(rowid);`
 
 // getSQLiteStmt replaces all PostgreSQL prepared statement placeholders (eg. $1, $2) with SQLite variant "?"
 func getSQLiteStmt(s string) string {
@@ -76,6 +77,8 @@ func (d *acmedb) Init(engine string, connection string) error {
 		_, err = d.DB.Exec(txtTable)
 	} else {
 		_, err = d.DB.Exec(txtTablePG)
+		// The PG table has an extra rowid that isn't primary key and thus not auto-indexed, add an index for it too
+		_, err = d.DB.Exec(txtTableIndexPG)
 	}
 	_, err = d.DB.Exec(txtTableIndex)
 	// If everything is fine, handle db upgrade tasks

--- a/db.go
+++ b/db.go
@@ -48,6 +48,8 @@ var txtTablePG = `
 		LastUpdate INT
 	);`
 
+var txtTableIndex = `CREATE INDEX IF NOT EXIST txtSubdomainIndex ON txt(Subdomain);`
+
 // getSQLiteStmt replaces all PostgreSQL prepared statement placeholders (eg. $1, $2) with SQLite variant "?"
 func getSQLiteStmt(s string) string {
 	re, _ := regexp.Compile("\\$[0-9]")
@@ -75,6 +77,7 @@ func (d *acmedb) Init(engine string, connection string) error {
 	} else {
 		_, err = d.DB.Exec(txtTablePG)
 	}
+	_, err = d.DB.Exec(txtTableIndex)
 	// If everything is fine, handle db upgrade tasks
 	if err == nil {
 		err = d.checkDBUpgrades(versionString)


### PR DESCRIPTION
Simple update that adds an index on the Subdomain field in the TXT table since it is a primary field used on WHERE clauses