### PR TITLE
add support for custom registration endpoint and/or custom path

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -237,7 +237,7 @@ func TestApiDeleteWithInvalidSubdomain(t *testing.T) {
 		"subdomain": "",
 		"txt":       ""}
 
-	router := setupRouter(false, false)
+	router := setupRouter(false, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
@@ -297,7 +297,7 @@ func TestApiDeleteWithInvalidTxt(t *testing.T) {
 		"subdomain": "",
 		"txt":       ""}
 
-	router := setupRouter(false, false)
+	router := setupRouter(false, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
@@ -333,7 +333,7 @@ func TestApiUpdateWithoutCredentials(t *testing.T) {
 }
 
 func TestApiDeleteWithoutCredentials(t *testing.T) {
-	router := setupRouter(false, false)
+	router := setupRouter(false, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
@@ -443,7 +443,7 @@ func TestApiDeleteWithCredentialsMockDB(t *testing.T) {
 	updateJSON["subdomain"] = "a097455b-52cc-4569-90c8-7a4b97c6eba8"
 	updateJSON["txt"] = validTxtData
 
-	router := setupRouter(false, true)
+	router := setupRouter(false, true, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
@@ -530,7 +530,7 @@ func TestApiManyDeleteWithCredentials(t *testing.T) {
 		"subdomain": "",
 		"txt":       ""}
 
-	router := setupRouter(true, false)
+	router := setupRouter(true, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
@@ -646,7 +646,7 @@ func TestApiManyDeleteWithIpCheckHeaders(t *testing.T) {
 		"subdomain": "",
 		"txt":       ""}
 
-	router := setupRouter(false, false)
+	router := setupRouter(false, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)

--- a/api_test.go
+++ b/api_test.go
@@ -468,18 +468,10 @@ func TestApiCustomRegistration(t *testing.T) {
 		ContainsKey("password").
 		NotContainsKey("error")
 
-	e = getExpect(t, server)
-	e.POST("/custom-registration").Expect().
-		Status(http.StatusCreated).
-		JSON().Object().
-		ContainsKey("fulldomain").
-		ContainsKey("subdomain").
-		ContainsKey("username").
-		ContainsKey("password").
-		NotContainsKey("error")
+	e.POST("/register").Expect().
+		Status(http.StatusNotFound)
 
 	// Shouldn't affect normal endpoints
-	e = getExpect(t, server)
 	e.GET("/health").Expect().Status(http.StatusOK)
 }
 
@@ -498,21 +490,13 @@ func TestApiCustomPath(t *testing.T) {
 		ContainsKey("password").
 		NotContainsKey("error")
 
-	e.POST("/topsecret/register").Expect().
-		Status(http.StatusCreated).
-		JSON().Object().
-		ContainsKey("fulldomain").
-		ContainsKey("subdomain").
-		ContainsKey("username").
-		ContainsKey("password").
-		NotContainsKey("error")
+	e.POST("/register").Expect().
+		Status(http.StatusNotFound)
 
 	// Make sure a normal endpoint is served under custom path too
-	e = getExpect(t, server)
 	e.GET("/topsecret/health").Expect().Status(http.StatusOK)
 
 	// The original should no longer work
-	e = getExpect(t, server)
 	e.GET("/health").Expect().Status(http.StatusNotFound)
 }
 
@@ -531,12 +515,6 @@ func TestApiCustomPathAndRegistration(t *testing.T) {
 		ContainsKey("password").
 		NotContainsKey("error")
 
-	e.POST("/topsecret/custom-registration").Expect().
-		Status(http.StatusCreated).
-		JSON().Object().
-		ContainsKey("fulldomain").
-		ContainsKey("subdomain").
-		ContainsKey("username").
-		ContainsKey("password").
-		NotContainsKey("error")
+	e.POST("/register").Expect().
+		Status(http.StatusNotFound)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -381,7 +381,7 @@ func TestApiDeleteWithCredentials(t *testing.T) {
 		"subdomain": "",
 		"txt":       ""}
 
-	router := setupRouter(false, false)
+	router := setupRouter(false, false, "", "")
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)

--- a/main.go
+++ b/main.go
@@ -123,11 +123,28 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		// Logwriter for saner log output
 		c.Log = stdlog.New(logwriter, "", 0)
 	}
-	if !Config.API.DisableRegistration {
-		api.POST("/register", webRegisterPost)
+	// Check for custom path, default to just / if not
+	path := "/"
+	if Config.API.Path != "" {
+		path = Config.API.Path
 	}
-	api.POST("/update", Auth(webUpdatePost))
-	api.GET("/health", healthCheck)
+	// Make sure path starts and ends with /
+	if path[0] != '/' {
+		path = "/" + path
+	}
+	if path[len(path)-1] != '/' {
+		path += "/"
+	}
+	// Check for custom registration endpoint, default to register if not given
+	registerEndpoint := "register"
+	if Config.API.RegisterEndpoint != "" {
+		registerEndpoint = Config.API.RegisterEndpoint
+	}
+	if !Config.API.DisableRegistration {
+		api.POST(path+registerEndpoint, webRegisterPost)
+	}
+	api.POST(path+"update", Auth(webUpdatePost))
+	api.GET(path+"health", healthCheck)
 
 	host := Config.API.IP + ":" + Config.API.Port
 

--- a/main.go
+++ b/main.go
@@ -129,10 +129,10 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		path = Config.API.Path
 	}
 	// Make sure path starts and ends with /
-	if path[0] != '/' {
+	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if path[len(path)-1] != '/' {
+	if !strings.HasSuffix(path, "/") {
 		path += "/"
 	}
 	// Check for custom registration endpoint, default to register if not given
@@ -140,6 +140,9 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 	if Config.API.RegisterEndpoint != "" {
 		registerEndpoint = Config.API.RegisterEndpoint
 	}
+	// Ensure registerEndpoint doesn't start with a /
+	registerEndpoint = strings.TrimPrefix(registerEndpoint, "/")
+	
 	if !Config.API.DisableRegistration {
 		api.POST(path+registerEndpoint, webRegisterPost)
 	}

--- a/types.go
+++ b/types.go
@@ -54,6 +54,8 @@ type httpapi struct {
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+	RegisterEndpoint    string `toml:"registration_endpoint"`
+	Path                string `tomp:"path"`
 }
 
 // Logging config


### PR DESCRIPTION
In reference to https://github.com/joohoi/acme-dns/issues/216 this addresses some of the options by making it possible to customize the path and/or the registration endpoint itself. This makes it possible to help keep a site more locked down by giving a custom path (any string is acceptable that is a valid uri, though testing hasn't been done for it, and should be probably), or optionally giving the registration endpoint a custom string.

Ex: set path to "/never-gonna-give-you-up/" will make all endpoints available under that prefix as /never-gonna-give-you-up/register, /never-gonna-give-you-up/update, etc - this is a basic security by obscurity but helps as a very simple implementation and only requires customizing the url on the client.

Similarly registration_endpoint can be set to just customize it, such as "secret-register" or "6469b532-bf2b-4523-b533-ca8ae4de3f08/register" and it will be available at /<registraion_endpoint> so further obscuring the path to at least swamp the system with bogus registrations.

Further security would probably be a decent idea as an optional implementation, either as an additional header or using basic auth. Preference would be for an additional header as that is fairly common and already a requirement anyways.

- [x] Updated test code to support custom path/registration endpoint
- [x] Added tests for verifying endpoints are served properly in the various configurations (path, registration, both)
- [x] Added registration_endpoint and path as options for httpapi
- [x] Updated main to pull in the config, defaulting to a path of / and a registration endpoint of register thus maintaining backwards compatibility if nothing is provided
- [x] Added logic to ensure path begins and ends with / even if not provided
- [x] Added logic to ensure registration_endpoint does not begin with /
- [ ] Add a regex or something that validates a path and endpoint string are valid URI constructs, just for sanity, not sure if that is worth bringing in all of regex for though